### PR TITLE
Fix `v1` image build

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,6 +44,11 @@ jobs:
     - name: check
       run: just check
 
+    - name: Write Ubuntu Pro token
+      run: |
+        mkdir -p .secrets
+        printf '%s' '${{ secrets.UBUNTU_PRO_TOKEN }}' > .secrets/ubuntu_pro_token
+
     - name: build
       run: just build ${{ matrix.version }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pkg.lock.bak
 metadata/
 
 .env
+
+.secrets/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ services:
         - MAJOR_VERSION
         - CRAN_DATE
         - REPOS
+      secrets:
+        - ubuntu_pro_token
     init: true
     platform: linux/amd64
   add-package:
@@ -49,3 +51,7 @@ services:
     environment:
       HOSTPLATFORM: ${HOSTPLATFORM}
       HOSTUID: ${HOSTUID}
+
+secrets:
+  ubuntu_pro_token:
+    file: ${UBUNTU_PRO_TOKEN_FILE:-.secrets/ubuntu_pro_token}

--- a/justfile
+++ b/justfile
@@ -15,6 +15,10 @@ build version:
     export BUILD_DATE=$(date -u +'%y-%m-%dT%H:%M:%SZ')
     export GITREF=$(git rev-parse --short HEAD)
 
+    # Ensure the Ubuntu Pro token secret file exists so the compose secrets reference resolves.
+    mkdir -p .secrets
+    test -f .secrets/ubuntu_pro_token || touch .secrets/ubuntu_pro_token
+
     # build the thing
     docker compose --env-file {{ version }}/env build --pull r
 

--- a/v1/Dockerfile
+++ b/v1/Dockerfile
@@ -9,6 +9,7 @@ COPY v1/dependencies.txt /root/dependencies.txt
 
 # add cran repo for R packages and install
 RUN --mount=type=cache,target=/var/cache/apt,id=apt-2004 \
+    --mount=type=secret,id=ubuntu_pro_token \
     echo "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" > /etc/apt/sources.list.d/cran.list &&\
     /usr/lib/apt/apt-helper download-file 'https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc' /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc &&\
     /root/docker-apt-install.sh /root/dependencies.txt
@@ -24,7 +25,9 @@ FROM base-r as builder
 
 # install build time dependencies 
 COPY v1/build-dependencies.txt /root/build-dependencies.txt
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-2004 /root/docker-apt-install.sh /root/build-dependencies.txt
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-2004 \
+    --mount=type=secret,id=ubuntu_pro_token \
+    /root/docker-apt-install.sh /root/build-dependencies.txt
 
 RUN mkdir -p /cache /renv/lib
 


### PR DESCRIPTION
Makes the changes necessary to continue building the `v1` image following this change to the base-docker image:
 * https://github.com/opensafely-core/base-docker/pull/40

Thanks to @remlapmot for doing all the work here!

I added a temporary commit to force the `v1` build to run on the PR (which doesn't happen by default, apparently because it's so slow) and confirmed that the previously broken apt-install phase is now running correctly.

Related Slack thread:
https://bennettoxford.slack.com/archives/C069YDR4NCA/p1782815886716039