### PR TITLE
Ensure secrets are available to all build steps

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,8 @@ services:
       args:
        - PACKAGE
        - REPOS
+      secrets:
+        - ubuntu_pro_token
     platform: linux/amd64
   rstudio:
     extends: r
@@ -42,6 +44,8 @@ services:
         # supplied by just
         - RSTUDIO_BASE_URL
         - RSTUDIO_DEB
+      secrets:
+        - ubuntu_pro_token
     ports:
       - 8787:8787
     platform: linux/amd64

--- a/v1/Dockerfile
+++ b/v1/Dockerfile
@@ -111,9 +111,11 @@ FROM r as rstudio
 
 # Install rstudio-server (and a few dependencies)
 COPY rstudio/rstudio-dependencies.txt /root/rstudio-dependencies.txt
-RUN --mount=type=cache,target=/var/cache/apt,id=apt-2004 /root/docker-apt-install.sh /root/rstudio-dependencies.txt &&\
-    test -f /var/cache/apt/"${RSTUDIO_DEB}" ||\
-    /usr/lib/apt/apt-helper download-file "${RSTUDIO_BASE_URL}${RSTUDIO_DEB}" /var/cache/apt/"${RSTUDIO_DEB}" &&\
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-2004 \
+    --mount=type=secret,id=ubuntu_pro_token \
+    /root/docker-apt-install.sh /root/rstudio-dependencies.txt &&\
+    { test -f /var/cache/apt/"${RSTUDIO_DEB}" ||\
+      /usr/lib/apt/apt-helper download-file "${RSTUDIO_BASE_URL}${RSTUDIO_DEB}" /var/cache/apt/"${RSTUDIO_DEB}"; } &&\
     apt-get install --no-install-recommends -y /var/cache/apt/"${RSTUDIO_DEB}"
 
 # Configuration


### PR DESCRIPTION
In Docker Compose, the `secrets` config is not automatically inherited when using `extends` (see [docs][1]) so we need to specify it for each service which needs it.

This follows on from the below PR which fixed the `just build v1` step but failed at `just build-rstudio v1`:
 * https://github.com/opensafely-core/r-docker/pull/198

[1]: https://docs.docker.com/reference/compose-file/services/#restrictions

---

Note to reviewer: I'll remove the temporary commit at the end before merging but I wanted to show the PR with all workflows passing
